### PR TITLE
Fixed - Submodule/apm needs tested

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fonts/FiraCodeiScript"]
+	path = fonts/FiraCodeiScript
+	url = https://github.com/kencrocken/FiraCodeiScript

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Notebook UI styles most core elements to make Atom feel right at home in the ear
 
 Notebook UI is based entirely on [Atom One Light UI](https://github.com/atom/one-light-ui) which excels at blending UI styles with syntax theme colors, unlike [other themes](https://atom.io/themes/blueprint-ui). Notebook UI's styles don't mesh with as many themes as Atom One but it looks great with probably all light or solarized syntax themes.
 
-It also relies on [Fira Code iScript](https://github.com/kencrocken/FiraCodeiScript) for handwritten font styling.
+It also relies on [Fira Code iScript](https://github.com/kencrocken/FiraCodeiScript) for handwritten font styling. Simply type Fira Code iScript into your editor settings font textbox to turn Fira Code iScript on for your editor.
 
 ## Beautifully archaic
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "main": "lib/main",
   "engines": {
     "atom": ">0.40.0"
-  }
+  },
+  "files":[
+    "fonts"
+    ]
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -81,18 +81,20 @@
 // Font -----------------
 
 //hackish workaround for when Fira Code iScript isn't installed
-@import url('https://cdn.rawgit.com/tonsky/FiraCode/1.205/distr/fira_code.css');
+
+
+
 @font-face{
   font-family: 'Fira Code iScript';
-  src: url('https://cdn.rawgit.com/kencrocken/FiraCodeiScript/master/FiraCodeiScript-Regular.ttf') format('truetype');
+  src: url('atom://notebook-ui/fonts/FiraCodeiScript/FiraCodeiScript-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
 }
 @font-face{
   font-family: 'Fira Code iScript';
-  src: url('https://cdn.rawgit.com/kencrocken/FiraCodeiScript/master/FiraCodeiScript-Italic.ttf') format('truetype');
+  src: url('atom://notebook-ui/fonts/FiraCodeiScript/FiraCodeiScript-Italic.ttf') format('truetype');
   font-weight: 400;
   font-style: italic;
 }
 
-@font-family: Fira Code iScript, system-ui;
+@font-family: 'Fira Code iScript', 'system-ui';


### PR DESCRIPTION
I've fixed the issue, but I haven't tested how apm will handle a submodule. We can punch the submodule out and just store them as regular files if it doesn't work, but atom is owned by github, so I would think it should. 

I added a note to the readme on how to toggle the font for the editor. I thought it was best this way. You just have to type or copy the font name into the editor settings. This makes it so you don't have to see your code that way and it keeps it from conflicting with other fonts packages. The UI all has the font automatically when you start up the theme.
